### PR TITLE
common: Fix SourceFlags length from u32 -> u16

### DIFF
--- a/chrony-candm/src/common.rs
+++ b/chrony-candm/src/common.rs
@@ -397,7 +397,7 @@ impl ChronySerialize for ChronyAddr {
 bitflags! {
     /// Flags associated with a time source
     #[derive(ChronySerialize)]
-    pub struct SourceFlags : u32 {
+    pub struct SourceFlags : u16 {
         const ONLINE = 0x1;
         const AUTOOFFLINE = 0x2;
         const IBURST = 0x4;


### PR DESCRIPTION
*Description of changes:*

* The actual size is 16-bits, from the C header: `uint16_t flags;`
* Fix issue with `SourceData` request where the expected size is two bytes longer.
* Async cmd timeout waiting for bytes that will never by sent.
* Blocking cmds report message smaller then expected: `message too short`.

Reference:
* https://github.com/mlichvar/chrony/blob/7b197953e8add5515b7e58c4638dc55aa4bb91b7/candm.h#L573


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
