### PR TITLE
Fix the size of SourceFlags in NtpSource requests

### DIFF
--- a/chrony-candm/src/request.rs
+++ b/chrony-candm/src/request.rs
@@ -164,6 +164,10 @@ pub struct NtpSource {
     pub max_delay_dev_ratio: ChronyFloat,
     pub min_delay: ChronyFloat,
     pub asymmetry: ChronyFloat,
+    // In the chrony sources, `flags` is 32 bits in requests and 16 bits in replies.
+    // So that we can use the same data type in both messages, we make it 16 bits
+    // everywhere and treat the two unused high bytes in the request as padding.
+    #[pad = 2]
     pub offset: ChronyFloat,
     pub flags: SourceFlags,
     pub filter_length: i32,


### PR DESCRIPTION
`SourceFlags` is used in both the `NtpSource` request and the `SourceData` reply, but it appears as two different sizes in the chrony sources even though it's the same set of flags. Therefore #3 fixed it in one place but broke it in another. This PR should get it right in both places.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

cc @kylemanna FYI