### PR TITLE
Update to version 0.1.2

### DIFF
--- a/chrony-candm/CHANGELOG.md
+++ b/chrony-candm/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.2] - 2024-02-26
+### Fixed
+- Fixed an issue with SourceData request size
+
+## [0.1.1] - 2021-12-23
+### Fixed
+- Fixed an issue constructing ChronyFloats from f64s
+
+## [0.1.0] - 2021-11-01
+### Added
+- Initial working version

--- a/chrony-candm/Cargo.toml
+++ b/chrony-candm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chrony-candm"
-version = "0.1.1"
+version = "0.1.2"
 authors = [ "Daniel Fox Franke <dff@amazon.com>" ]
 edition = "2018"
 description = "Library for communication with Chrony's control & monitoring interface"


### PR DESCRIPTION
*Description of changes:*
Upgrading chrony-candm to 0.1.2 to bring in bug fixes for source data request length.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
