### PR TITLE
ServerStats: handle ServerStats4 protocol

### DIFF
--- a/chrony-candm/src/reply.rs
+++ b/chrony-candm/src/reply.rs
@@ -201,6 +201,28 @@ pub struct ServerStats {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, ChronySerialize)]
+pub struct ServerStats4 {
+    pub ntp_hits: u64,
+    pub nke_hits: u64,
+    pub cmd_hits: u64,
+    pub ntp_drops: u64,
+    pub nke_drops: u64,
+    pub cmd_drops: u64,
+    pub log_drops: u64,
+    pub ntp_auth_hits: u64,
+    pub ntp_interleaved_hits: u64,
+    pub ntp_timestamps: u64,
+    pub ntp_span_seconds: u64,
+    pub ntp_daemon_rx_timestamps: u64,
+    pub ntp_daemon_tx_timestamps: u64,
+    pub ntp_kernel_rx_timestamps: u64,
+    pub ntp_kernel_tx_timestamps: u64,
+    pub ntp_hw_rx_timestamps: u64,
+    pub ntp_hw_tx_timestamps: u64,
+    reserved: [u64; 4],
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, ChronySerialize)]
 pub struct ManualListSample {
     pub when: SystemTime,
     pub slewed_offset: ChronyFloat,
@@ -377,6 +399,8 @@ pub enum ReplyBody {
     ClientAccessesByIndex3(ClientAccessesByIndex),
     ServerStats2(ServerStats),
     SelectData(SelectData),
+    #[cmd = 25]
+    ServerStats4(ServerStats4),
 }
 
 /// A reply from Chrony

--- a/chrony-candm/src/request.rs
+++ b/chrony-candm/src/request.rs
@@ -378,7 +378,7 @@ impl RequestBody {
             Self::Smoothing => reply::Smoothing::length(),
             Self::SmoothTime(_) => 0,
             Self::Refresh => 0,
-            Self::ServerStats => reply::ServerStats::length(),
+            Self::ServerStats => reply::ServerStats4::length(),
             Self::Local2(_) => 0,
             Self::NtpData(_) => reply::NtpData::length(),
             Self::Shutdown => 0,


### PR DESCRIPTION
Hi!,

In chrony 4.4, they added timestamp counters + moved the fields to 64 bits. This fixes that by supporting both protos.

Fixes #7


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Thanks!
