### PR TITLE
Adding flexibility over the path for the chronyd UDS socket

### DIFF
--- a/chrony-candm/Cargo.toml
+++ b/chrony-candm/Cargo.toml
@@ -22,6 +22,7 @@ num_enum = "0.5"
 rand = "0.8"
 siphasher = "0.3"
 tokio = { version = "1", features = [ "macros", "net", "rt", "sync", "time" ] , optional = true }
+tempfile = { version = "3" }
 
 [dev-dependencies]
 chrono = "0.4"


### PR DESCRIPTION
*Issue #, if available:* #9

*Description of changes:*
This commit ensures that one is able to make calls over UDS over a customizable path. This does not break the existing implementation and keeps it backward compatible, while snuring that it gives us more control on directing towards a customized file path.

There's an additional dependency brought on a tempfile create and moving the client socket into a temp directory, but this isn't a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
