### PR TITLE
Simplify Async

### DIFF
--- a/chrony-candm/CHANGELOG.md
+++ b/chrony-candm/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2025-04-18
+### Added
+- UnixDatagramClient so that the async UDS socket can be easily re-used or otherwise controlled by the caller
+
+## [0.1.3] - 2025-04-17
+### Added
+- async query_uds function that works without spawning a whole runtime
+
 ## [0.1.2] - 2024-02-26
 ### Fixed
 - Fixed an issue with SourceData request size

--- a/chrony-candm/CHANGELOG.md
+++ b/chrony-candm/CHANGELOG.md
@@ -4,13 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.4] - 2025-04-18
-### Added
-- UnixDatagramClient so that the async UDS socket can be easily re-used or otherwise controlled by the caller
-
-## [0.1.3] - 2025-04-17
+## [0.1.3] - 2025-04-18
 ### Added
 - async query_uds function that works without spawning a whole runtime
+- UnixDatagramClient so that the async UDS socket can be easily re-used or otherwise controlled by the caller
 
 ## [0.1.2] - 2024-02-26
 ### Fixed

--- a/chrony-candm/Cargo.toml
+++ b/chrony-candm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chrony-candm"
-version = "0.1.4"
+version = "0.1.3"
 authors = [ "Daniel Fox Franke <dff@amazon.com>" ]
 edition = "2018"
 description = "Library for communication with Chrony's control & monitoring interface"

--- a/chrony-candm/Cargo.toml
+++ b/chrony-candm/Cargo.toml
@@ -25,6 +25,7 @@ tokio = { version = "1", features = [ "macros", "net", "rt", "sync", "time" ] , 
 
 [dev-dependencies]
 chrono = "0.4"
+clap = { version = "4", features = ["derive"] }
 
 [features]
 default = [ "with_tokio" ]

--- a/chrony-candm/Cargo.toml
+++ b/chrony-candm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chrony-candm"
-version = "0.1.2"
+version = "0.1.3"
 authors = [ "Daniel Fox Franke <dff@amazon.com>" ]
 edition = "2018"
 description = "Library for communication with Chrony's control & monitoring interface"

--- a/chrony-candm/Cargo.toml
+++ b/chrony-candm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chrony-candm"
-version = "0.1.3"
+version = "0.1.4"
 authors = [ "Daniel Fox Franke <dff@amazon.com>" ]
 edition = "2018"
 description = "Library for communication with Chrony's control & monitoring interface"
@@ -21,6 +21,7 @@ libc = "0.2"
 num_enum = "0.5"
 rand = "0.8"
 siphasher = "0.3"
+thiserror = "2"
 tokio = { version = "1", features = [ "macros", "net", "rt", "sync", "time" ] , optional = true }
 
 [dev-dependencies]

--- a/chrony-candm/src/async_net.rs
+++ b/chrony-candm/src/async_net.rs
@@ -17,6 +17,7 @@ use tokio::sync::mpsc::error::SendError;
 use tokio::sync::OnceCell;
 use tokio::time::Instant;
 
+use crate::common::QueryError;
 use crate::net::ClientOptions;
 use crate::reply::Reply;
 use crate::request::{Request, RequestBody};
@@ -75,7 +76,7 @@ impl Drop for UnixDatagramClient {
 
 #[cfg(unix)]
 impl UnixDatagramClient {
-    async fn new() -> std::io::Result<UnixDatagramClient> {
+    pub async fn new() -> std::io::Result<UnixDatagramClient> {
         let id: [u8; 16] = rand::random();
         let mut path = b"/var/run/chrony/client-000102030405060708090a0b0c0d0e0f.sock".clone();
         hex::encode_to_slice(id, &mut path[23..55]).unwrap();
@@ -85,6 +86,55 @@ impl UnixDatagramClient {
         std::fs::set_permissions(path_str, Permissions::from_mode(0o777))?;
         client.connect("/var/run/chrony/chronyd.sock")?;
         Ok(client)
+    }
+
+    /// Query chronyd using this UnixDomainSocket
+    ///
+    /// Sends a request to a server and waits for the response
+    ///
+    /// # Errors
+    /// See [`QueryError`] for more info
+    ///
+    /// # NOTE
+    /// This function takes `&mut self` unnecessarily to prevent the footgun of making concurrent requests to `chronyd`
+    pub async fn query(
+        &mut self,
+        request: RequestBody,
+        options: ClientOptions,
+    ) -> Result<Reply, QueryError> {
+        use bytes::BytesMut;
+        let request = Request {
+            sequence: rand::random(),
+            attempt: 0,
+            body: request,
+        };
+
+        let mut send_buf = BytesMut::with_capacity(request.length());
+        request.serialize(&mut send_buf);
+        let mut recv_buf = [0; 1500];
+        let mut attempt = 0;
+
+        while attempt < options.n_tries {
+            self.0.send(&send_buf).await.map_err(QueryError::Send)?;
+            let Ok(io_result) =
+                tokio::time::timeout(options.timeout, self.0.recv(&mut recv_buf)).await
+            else {
+                attempt += 1;
+                continue;
+            };
+            let size = io_result.map_err(QueryError::Recv)?;
+            let mut msg = &recv_buf[..size];
+            let reply = Reply::deserialize(&mut msg)?;
+            if reply.sequence == request.sequence {
+                return Ok(reply);
+            } else {
+                return Err(QueryError::SequenceMismatch {
+                    expected: request.sequence,
+                    received: reply.sequence,
+                });
+            }
+        }
+        Err(QueryError::Timeout)
     }
 }
 
@@ -526,45 +576,6 @@ async fn client_task(options: ClientOptions, mut receiver: RequestReceiver) {
 /// This has retry logic based off [`ClientOptions`]
 #[cfg(unix)]
 pub async fn query_uds(request: RequestBody, options: ClientOptions) -> std::io::Result<Reply> {
-    use bytes::BytesMut;
-
-    let client = UnixDatagramClient::new().await?;
-
-    let request = Request {
-        sequence: rand::random(),
-        attempt: 0,
-        body: request,
-    };
-
-    let mut send_buf = BytesMut::with_capacity(request.length());
-    request.serialize(&mut send_buf);
-    let mut recv_buf = [0; 1500];
-    let mut attempt = 0;
-
-    while attempt < options.n_tries {
-        client.0.send(&send_buf).await?;
-        let Ok(io_result) =
-            tokio::time::timeout(options.timeout, client.0.recv(&mut recv_buf)).await
-        else {
-            attempt += 1;
-            continue;
-        };
-        let size = io_result?;
-        let mut msg = &recv_buf[..size];
-        let reply = Reply::deserialize(&mut msg)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-        if reply.sequence == request.sequence {
-            return Ok(reply);
-        } else {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "Sequence number mismatch",
-            ));
-        }
-    }
-    // timed out
-    Err(std::io::Error::new(
-        std::io::ErrorKind::TimedOut,
-        format!("Timed out after {n} retries", n = options.n_tries),
-    ))
+    let mut client = UnixDatagramClient::new().await?;
+    client.query(request, options).await.map_err(QueryError::into_io)
 }

--- a/chrony-candm/src/net.rs
+++ b/chrony-candm/src/net.rs
@@ -14,11 +14,11 @@ use std::ops::{Deref, DerefMut};
 use std::time::Duration;
 
 #[cfg(unix)]
-use std::os::unix::net::UnixDatagram;
-#[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+#[cfg(unix)]
+use std::os::unix::net::UnixDatagram;
 
 pub const DEFAULT_PORT: u16 = 323;
 
@@ -84,7 +84,6 @@ impl AsMut<UnixDatagram> for UnixDatagramClient {
         &mut self.0
     }
 }
-
 
 #[cfg(unix)]
 impl Deref for UnixDatagramClient {
@@ -164,7 +163,9 @@ fn blocking_query_loop<Sock: DgramSocket>(
                 }
             }
             Err(e) => {
-                if e.kind() == std::io::ErrorKind::TimedOut || e.kind() == std::io::ErrorKind::WouldBlock {
+                if e.kind() == std::io::ErrorKind::TimedOut
+                    || e.kind() == std::io::ErrorKind::WouldBlock
+                {
                     attempt += 1;
                     if attempt == options.n_tries {
                         return Err(e);
@@ -195,7 +196,7 @@ pub fn blocking_query<Server: std::net::ToSocketAddrs>(
 #[cfg(unix)]
 pub fn blocking_query_uds(
     request_body: RequestBody,
-    options: ClientOptions
+    options: ClientOptions,
 ) -> std::io::Result<Reply> {
     let sock = UnixDatagramClient::new()?;
     sock.set_read_timeout(Some(options.timeout))?;


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* The async_net portion of candm is drastically overcomplicated. Looking at this logic in comparison with the blocking `net` version in this same codebase really shows this.

Add a public function `query_uds` which creates a UDS client, sends a request directly in this async function, and retries based on tokio `timeout` functionality.

deprecated the `async_net::Client` code. Deleting is a breaking change that would need to happen in V2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
